### PR TITLE
Remove custom HelpFunc

### DIFF
--- a/command.go
+++ b/command.go
@@ -184,7 +184,7 @@ func (c *Command) Execute() error {
 	versionCalled, err := c.Flags().GetBool("version")
 	if err != nil {
 		// Again, shouldn't ever get here
-		return fmt.Errorf("version was call for but unset: %w", err)
+		return fmt.Errorf("could not parse version flag: %w", err)
 	}
 
 	// If -v/--version was called, call the defined versionFunc and exit so that

--- a/command.go
+++ b/command.go
@@ -45,7 +45,6 @@ func New(name string, options ...Option) *Command {
 		args:        os.Args[1:],
 		name:        name,
 		version:     "dev",
-		helpFunc:    defaultHelp,
 		versionFunc: defaultVersion,
 		short:       "A placeholder for something cool",
 	}
@@ -72,12 +71,6 @@ type Command struct {
 
 	// flags is the set of flags for this command.
 	flags *pflag.FlagSet
-
-	// helpFunc is the function that gets called when the user calls -h/--help.
-	//
-	// It can be overridden by the user to customise their help output using
-	// the [HelpFunc] [Option].
-	helpFunc func(cmd *Command) error
 
 	// versionFunc is the function thatgets called when the user calls -v/--version.
 	//
@@ -181,10 +174,7 @@ func (c *Command) Execute() error {
 	// If -h/--help was called, call the defined helpFunc and exit so that
 	// the run function is never called.
 	if helpCalled {
-		if c.helpFunc == nil {
-			return errors.New("helpFunc was nil")
-		}
-		if err = c.helpFunc(c); err != nil {
+		if err = defaultHelp(c); err != nil {
 			return fmt.Errorf("help function returned an error: %w", err)
 		}
 		return nil

--- a/command.go
+++ b/command.go
@@ -168,7 +168,7 @@ func (c *Command) Execute() error {
 	helpCalled, err := c.Flags().GetBool("help")
 	if err != nil {
 		// We shouldn't ever get here because we define a default for help
-		return fmt.Errorf("help was called for but unset: %w", err)
+		return fmt.Errorf("could not parse help flag: %w", err)
 	}
 
 	// If -h/--help was called, call the defined helpFunc and exit so that

--- a/command_test.go
+++ b/command_test.go
@@ -119,19 +119,6 @@ func TestHelp(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "custom",
-			cmd: cli.New(
-				"test",
-				cli.Args([]string{"--help"}),
-				cli.HelpFunc(func(cmd *cli.Command) error {
-					fmt.Fprintln(cmd.Stderr(), "Do something custom")
-					return nil
-				}),
-			),
-			golden:  "custom-help.txt",
-			wantErr: false,
-		},
-		{
 			name: "with examples",
 			cmd: cli.New(
 				"test",

--- a/option.go
+++ b/option.go
@@ -83,16 +83,6 @@ func VersionFunc(fn func(cmd *Command) error) Option {
 	}
 }
 
-// HelpFunc is an [Option] that allows for a custom implementation of the -h/--help flag.
-//
-// A [Command] will have a default implementation of this function that prints a default
-// format of the help to [os.Stderr].
-func HelpFunc(fn func(cmd *Command) error) Option {
-	return func(cmd *Command) {
-		cmd.helpFunc = fn
-	}
-}
-
 // SubCommands is an [Option] that attaches 1 or more subcommands to the command being configured.
 func SubCommands(cmds ...*Command) Option {
 	return func(cmd *Command) {

--- a/testdata/custom-help.txt
+++ b/testdata/custom-help.txt
@@ -1,1 +1,0 @@
-Do something custom


### PR DESCRIPTION
- **Remove HelpFunc option**
- **Clarify help parse error message**
- **Clarify version parse error message**

<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Realised having a custom `HelpFunc` was largely pointless unless I export all the `Command` internals, which I don't want to do

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
