### PR TITLE
Fix help colours

### DIFF
--- a/internal/colour/colour.go
+++ b/internal/colour/colour.go
@@ -10,8 +10,8 @@ import "os"
 // alignment of [text/tabwriter].
 const (
 	CodeReset = "\x1b[000000m" // Reset all attributes
-	CodeTitle = "\x1b[1;37;4m" // Bold, white & underlined
-	CodeBold  = "\x1b[1;0037m" // Bold & white
+	CodeTitle = "\x1b[1;39;4m" // Bold, white & underlined
+	CodeBold  = "\x1b[1;0039m" // Bold & white
 )
 
 // Title returns the given text in a title style, bold white and underlined.


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Fixes the title colour appearing dimmed as some terminals interpret HiWhite differently

### Before

<img width="547" alt="image" src="https://github.com/user-attachments/assets/699a995b-135b-49e7-990d-551f8a65b01f">

### After

<img width="551" alt="image" src="https://github.com/user-attachments/assets/6780624c-3ccd-45ea-9493-03cd9ac65ac2">
