### PR TITLE
Change flag storage to reduce memory use

### DIFF
--- a/internal/flag/set_test.go
+++ b/internal/flag/set_test.go
@@ -36,7 +36,7 @@ func TestParse(t *testing.T) {
 				t.Helper()
 				f, exists := set.Get("something")
 				test.False(t, exists)
-				test.Equal(t, f, flag.Entry{})
+				test.Equal(t, f, nil)
 
 				test.EqualFunc(t, set.Args(), nil, slices.Equal)
 			},
@@ -53,7 +53,7 @@ func TestParse(t *testing.T) {
 				t.Helper()
 				f, exists := set.Get("something")
 				test.False(t, exists)
-				test.Equal(t, f, flag.Entry{})
+				test.Equal(t, f, nil)
 
 				test.EqualFunc(t, set.Args(), []string{"some", "args", "here", "no", "flags"}, slices.Equal)
 			},
@@ -70,7 +70,7 @@ func TestParse(t *testing.T) {
 				t.Helper()
 				f, exists := set.Get("something")
 				test.False(t, exists)
-				test.Equal(t, f, flag.Entry{})
+				test.Equal(t, f, nil)
 
 				test.EqualFunc(t, set.Args(), []string{"some", "args", "here", "no", "flags", "extra", "args"}, slices.Equal)
 				test.EqualFunc(t, set.ExtraArgs(), []string{"extra", "args"}, slices.Equal)
@@ -88,7 +88,7 @@ func TestParse(t *testing.T) {
 				t.Helper()
 				f, exists := set.Get("flag")
 				test.False(t, exists)
-				test.Equal(t, f, flag.Entry{})
+				test.Equal(t, f, nil)
 
 				test.EqualFunc(t, set.Args(), []string{"some", "args", "here"}, slices.Equal)
 			},
@@ -827,6 +827,7 @@ func TestParse(t *testing.T) {
 				// Get by short
 				entry, exists = set.GetShort('c')
 				test.False(t, exists) // Short shouldn't exist
+				test.Equal(t, entry, nil)
 			},
 			args:    []string{"--count", "1"},
 			wantErr: false,
@@ -856,6 +857,7 @@ func TestParse(t *testing.T) {
 				// Get by short
 				entry, exists = set.GetShort('c')
 				test.False(t, exists) // Short shouldn't exist
+				test.Equal(t, entry, nil)
 			},
 			args:    []string{"-c", "1"},
 			wantErr: true,
@@ -968,7 +970,7 @@ func TestFlagSet(t *testing.T) {
 				t.Helper()
 				f, exists := set.Get("missing")
 				test.False(t, exists)
-				test.Equal(t, f, flag.Entry{})
+				test.Equal(t, f, nil)
 			},
 		},
 		{
@@ -981,7 +983,7 @@ func TestFlagSet(t *testing.T) {
 				t.Helper()
 				f, exists := set.GetShort('d')
 				test.False(t, exists)
-				test.Equal(t, f, flag.Entry{})
+				test.Equal(t, f, nil)
 			},
 		},
 		{
@@ -994,7 +996,7 @@ func TestFlagSet(t *testing.T) {
 				t.Helper()
 				f, exists := set.Get("missing")
 				test.False(t, exists)
-				test.Equal(t, f, flag.Entry{})
+				test.Equal(t, f, nil)
 			},
 		},
 		{
@@ -1007,7 +1009,7 @@ func TestFlagSet(t *testing.T) {
 				t.Helper()
 				f, exists := set.GetShort('m')
 				test.False(t, exists)
-				test.Equal(t, f, flag.Entry{})
+				test.Equal(t, f, nil)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Changes `Entry` to `*Entry` in the internal flagset storage so that we can look up the same memory from shorthand or flag name.

Benchstat seems to suggest that although it allocates more (pointers rather than stack copies), the end result is actually faster
and uses 37% less memory when constructing a typical cli with `cli.New`

```shell
goos: darwin
goarch: amd64
pkg: github.com/FollowTheProcess/cli
cpu: Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz
              │ before.txt  │             after.txt              │
              │   sec/op    │   sec/op     vs base               │
ExecuteHelp-8   7.910µ ± 1%   7.799µ ± 1%  -1.41% (p=0.000 n=20)
New-8           1.886µ ± 0%   1.741µ ± 0%  -7.69% (p=0.000 n=20)
geomean         3.862µ        3.685µ       -4.60%

              │  before.txt  │              after.txt               │
              │     B/op     │     B/op      vs base                │
ExecuteHelp-8   5.347Ki ± 0%   5.347Ki ± 0%    0.00% (p=0.001 n=20)
New-8           3.079Ki ± 0%   1.953Ki ± 0%  -36.57% (p=0.000 n=20)
geomean         4.057Ki        3.232Ki       -20.36%

              │ before.txt │              after.txt              │
              │ allocs/op  │ allocs/op   vs base                 │
ExecuteHelp-8   81.00 ± 0%   81.00 ± 0%       ~ (p=1.000 n=20) ¹
New-8           24.00 ± 0%   26.00 ± 0%  +8.33% (p=0.000 n=20)
geomean         44.09        45.89       +4.08%
¹ all samples are equal
```
