### PR TITLE
No longer error if e.g `cli.Version` is passed an empty string

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -706,21 +706,6 @@ func TestOptionValidation(t *testing.T) {
 			errMsg:  "cannot set Args to nil",
 		},
 		{
-			name:    "empty version",
-			options: []cli.Option{cli.Version("")},
-			errMsg:  "cannot set Version to an empty string",
-		},
-		{
-			name:    "empty commit",
-			options: []cli.Option{cli.Commit("")},
-			errMsg:  "cannot set Commit to an empty string",
-		},
-		{
-			name:    "empty build date",
-			options: []cli.Option{cli.BuildDate("")},
-			errMsg:  "cannot set BuildDate to an empty string",
-		},
-		{
 			name:    "nil VersionFunc",
 			options: []cli.Option{cli.VersionFunc(nil)},
 			errMsg:  "cannot set VersionFunc to nil",

--- a/option.go
+++ b/option.go
@@ -267,9 +267,6 @@ func OverrideArgs(args []string) Option {
 //	cli.New("test", cli.Version("v1.2.3"))
 func Version(version string) Option {
 	f := func(cfg *config) error {
-		if version == "" {
-			return errors.New("cannot set Version to an empty string")
-		}
 		cfg.version = version
 		return nil
 	}
@@ -289,9 +286,6 @@ func Version(version string) Option {
 // [ldflags]: https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
 func Commit(commit string) Option {
 	f := func(cfg *config) error {
-		if commit == "" {
-			return errors.New("cannot set Commit to an empty string")
-		}
 		cfg.commit = commit
 		return nil
 	}
@@ -311,9 +305,6 @@ func Commit(commit string) Option {
 // [ldflags]: https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
 func BuildDate(date string) Option {
 	f := func(cfg *config) error {
-		if date == "" {
-			return errors.New("cannot set BuildDate to an empty string")
-		}
 		cfg.buildDate = date
 		return nil
 	}


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
I thought requiring it was set to something was a good idea but this breaks builds where ldflags are not set (such as `go install`)

Closes https://github.com/FollowTheProcess/spok/issues/177
