### PR TITLE
Indent examples in line with other help sections

### DIFF
--- a/command.go
+++ b/command.go
@@ -185,7 +185,7 @@ type example struct {
 
 // String implements [fmt.Stringer] for [Example].
 func (e example) String() string {
-	return fmt.Sprintf("\n# %s\n$ %s\n", e.comment, e.command)
+	return fmt.Sprintf("\n  # %s\n  $ %s\n", e.comment, e.command)
 }
 
 // Execute parses the flags and arguments, and invokes the Command's Run

--- a/testdata/TestHelp/with-examples.txt
+++ b/testdata/TestHelp/with-examples.txt
@@ -3,11 +3,11 @@ A placeholder for something cool
 Usage: test [OPTIONS] ARGS...
 
 Examples:
-# Do a thing
-$ test do thing --now
+  # Do a thing
+  $ test do thing --now
 
-# Do a different thing
-$ test do thing --different
+  # Do a different thing
+  $ test do thing --different
 
 Options:
   -h  --help     bool  Show help for test [default false]


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Aligns the `Examples` section with the others in the `--help` output, indenting with 2 spaces
