### PR TITLE
Refactor `cli.New` to reduce memory allocation overhead

### DIFF
--- a/command.go
+++ b/command.go
@@ -51,21 +51,24 @@ func New(name string, options ...Option) (*Command, error) {
 		argValidator: AnyArgs(),
 	}
 
-	// Ensure we always have at least help and version flags
-	defaultOptions := []Option{
-		Flag(&cfg.helpCalled, "help", 'h', false, fmt.Sprintf("Show help for %s", name)),
-		Flag(&cfg.versionCalled, "version", 'V', false, fmt.Sprintf("Show version info for %s", name)),
-	}
-
-	toApply := slices.Concat(options, defaultOptions)
-
 	// Apply the options, gathering up all the validation errors
 	// to report in one go
 	var errs error
-	for _, option := range toApply {
+	for _, option := range options {
 		if err := option.apply(&cfg); err != nil {
 			errs = errors.Join(errs, err)
 		}
+	}
+
+	// Ensure we always have at least help and version flags
+	err := Flag(&cfg.helpCalled, "help", 'h', false, fmt.Sprintf("Show help for %s", name)).apply(&cfg)
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	err = Flag(&cfg.versionCalled, "version", 'V', false, fmt.Sprintf("Show version info for %s", name)).apply(&cfg)
+	if err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	if errs != nil {

--- a/command.go
+++ b/command.go
@@ -55,21 +55,15 @@ func New(name string, options ...Option) (*Command, error) {
 	// to report in one go
 	var errs error
 	for _, option := range options {
-		if err := option.apply(&cfg); err != nil {
-			errs = errors.Join(errs, err)
-		}
+		errs = errors.Join(errs, option.apply(&cfg))
 	}
 
 	// Ensure we always have at least help and version flags
 	err := Flag(&cfg.helpCalled, "help", 'h', false, fmt.Sprintf("Show help for %s", name)).apply(&cfg)
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
+	errs = errors.Join(errs, err) // nil errors are discarded in join
 
 	err = Flag(&cfg.versionCalled, "version", 'V', false, fmt.Sprintf("Show version info for %s", name)).apply(&cfg)
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
+	errs = errors.Join(errs, err)
 
 	if errs != nil {
 		return nil, errs

--- a/command.go
+++ b/command.go
@@ -60,18 +60,16 @@ func New(name string, options ...Option) (*Command, error) {
 	toApply := slices.Concat(options, defaultOptions)
 
 	// Apply the options, gathering up all the validation errors
-	// to report in one go. Each option returns only one error
-	// so this can be pre-allocated.
-	errs := make([]error, 0, len(toApply))
+	// to report in one go
+	var errs error
 	for _, option := range toApply {
-		err := option.apply(&cfg)
-		if err != nil {
-			errs = append(errs, err)
+		if err := option.apply(&cfg); err != nil {
+			errs = errors.Join(errs, err)
 		}
 	}
 
-	if len(errs) > 0 {
-		return nil, errors.Join(errs...)
+	if errs != nil {
+		return nil, errs
 	}
 
 	// Additional validation that can't be done per-option


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Tweaks `cli.New` to reduce the number of memory allocations it does, some low hanging fruit here it seems...

```plain
goos: darwin
goarch: amd64
pkg: github.com/FollowTheProcess/cli
cpu: Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz
      │ before.txt  │             after.txt              │
      │   sec/op    │   sec/op     vs base               │
New-8   2.823µ ± 1%   2.600µ ± 1%  -7.90% (p=0.000 n=10)

      │  before.txt  │              after.txt               │
      │     B/op     │     B/op      vs base                │
New-8   2.720Ki ± 0%   2.250Ki ± 0%  -17.27% (p=0.000 n=10)

      │ before.txt │             after.txt              │
      │ allocs/op  │ allocs/op   vs base                │
New-8   38.00 ± 0%   34.00 ± 0%  -10.53% (p=0.000 n=10)
```
