### PR TITLE
Add `t.Parallel()` to all tests and subtests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     - nestif # cyclop does this
     - nlreturn # Similar to wsl, I think best left to judgement
     - nonamedreturns # Named returns are often helpful, it's naked returns that are the issue
-    - paralleltest # I've never had Go tests take longer than a few seconds, it's fine
     - varnamelen # Lots of false positives of things that are fine
     - wrapcheck # Not every error must be wrapped
     - wsl # Very aggressive, some of this I like but tend to do anyway

--- a/args_test.go
+++ b/args_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestArgValidators(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string       // Identifier of the test case
 		stdout  string       // Desired output to stdout
@@ -280,6 +281,7 @@ func TestArgValidators(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			stderr := &bytes.Buffer{}
 			stdout := &bytes.Buffer{}
 

--- a/command_test.go
+++ b/command_test.go
@@ -22,6 +22,7 @@ var (
 )
 
 func TestExecute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string       // Name of the test case
 		stdout  string       // Expected output to stdout
@@ -61,6 +62,7 @@ func TestExecute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var force bool
 
 			stderr := &bytes.Buffer{}
@@ -91,6 +93,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestSubCommandExecute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string   // Test case name
 		stdout  string   // Expected stdout
@@ -187,6 +190,7 @@ func TestSubCommandExecute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var (
 				force     bool
 				something string
@@ -268,6 +272,7 @@ func TestSubCommandExecute(t *testing.T) {
 }
 
 func TestPositionalArgs(t *testing.T) {
+	t.Parallel()
 	sub := func() (*cli.Command, error) {
 		return cli.New(
 			"sub",
@@ -432,6 +437,7 @@ func TestPositionalArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			stdout := &bytes.Buffer{}
 
 			// Test specific overrides to the options in the table
@@ -456,6 +462,7 @@ func TestPositionalArgs(t *testing.T) {
 }
 
 func TestHelp(t *testing.T) {
+	t.Parallel()
 	sub1 := func() (*cli.Command, error) {
 		return cli.New(
 			"sub1",
@@ -608,6 +615,7 @@ func TestHelp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			snap := snapshot.New(t, snapshot.Update(*update))
 
 			stderr := &bytes.Buffer{}
@@ -641,6 +649,7 @@ func TestHelp(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string       // Name of the test case
 		stderr  string       // Expected output to stderr
@@ -748,6 +757,7 @@ func TestVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			stderr := &bytes.Buffer{}
 			stdout := &bytes.Buffer{}
 
@@ -774,6 +784,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestOptionValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string       // Name of the test case
 		errMsg  string       // Expected error message
@@ -879,6 +890,7 @@ func TestOptionValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := cli.New("test", tt.options...)
 			test.Err(t, err)                      // Invalid option should have triggered an error
 			test.Equal(t, err.Error(), tt.errMsg) // Error message was not as expected
@@ -887,6 +899,7 @@ func TestOptionValidation(t *testing.T) {
 }
 
 func TestDuplicateSubCommands(t *testing.T) {
+	t.Parallel()
 	sub1 := func() (*cli.Command, error) {
 		return cli.New(
 			"sub1",
@@ -921,6 +934,7 @@ func TestDuplicateSubCommands(t *testing.T) {
 }
 
 func TestCommandNoRunNoSub(t *testing.T) {
+	t.Parallel()
 	_, err := cli.New(
 		"root",
 		cli.OverrideArgs([]string{}),
@@ -930,6 +944,7 @@ func TestCommandNoRunNoSub(t *testing.T) {
 }
 
 func TestExecuteNilCommand(t *testing.T) {
+	t.Parallel()
 	var cmd *cli.Command
 	err := cmd.Execute()
 	test.Err(t, err)
@@ -943,6 +958,7 @@ func TestExecuteNilCommand(t *testing.T) {
 // shuffles the order of the options and asserts the Command we get
 // out behaves the same as a baseline.
 func TestCommandOptionOrder(t *testing.T) {
+	t.Parallel()
 	baseLineStdout := &bytes.Buffer{}
 	baseLineStderr := &bytes.Buffer{}
 

--- a/internal/colour/colour.go
+++ b/internal/colour/colour.go
@@ -7,6 +7,7 @@ package colour
 import (
 	"os"
 	"sync"
+	"sync/atomic"
 )
 
 // ANSI codes for coloured output, they are all the same length so as not to throw off
@@ -20,7 +21,7 @@ const (
 // Disable is a flag that disables all colour text, it overrides both
 // $FORCE_COLOR and $NO_COLOR, setting it to true will always make this
 // package return plain text and not check any other config.
-var Disable = false
+var Disable atomic.Bool
 
 // getColourOnce is a [sync.OnceValues] function that returns the state of
 // $NO_COLOR and $FORCE_COLOR, once and only once to avoid us calling
@@ -55,7 +56,7 @@ func Bold(text string) string {
 // [Disable] is true then nothing else is checked and plain text is returned.
 func sprint(code, text string) string {
 	// Our global variable is above all else
-	if Disable {
+	if Disable.Load() {
 		return text
 	}
 

--- a/internal/flag/flag_test.go
+++ b/internal/flag/flag_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 func TestFlaggableTypes(t *testing.T) {
+	t.Parallel()
 	// We can't do table testing here because Flag[T] is a different type for each test
 	// so we can't do a []Flag[T] which is needed to define the test cases
 	// so strap in for a bunch of copy pasta
 	t.Run("int valid", func(t *testing.T) {
+		t.Parallel()
 		var i int
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int value")
 		test.Ok(t, err)
@@ -28,6 +30,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int invalid", func(t *testing.T) {
+		t.Parallel()
 		var i int
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int value")
 		test.Ok(t, err)
@@ -42,6 +45,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int8 valid", func(t *testing.T) {
+		t.Parallel()
 		var i int8
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int8 value")
 		test.Ok(t, err)
@@ -54,6 +58,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int8 invalid", func(t *testing.T) {
+		t.Parallel()
 		var i int8
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int8 value")
 		test.Ok(t, err)
@@ -68,6 +73,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int16 valid", func(t *testing.T) {
+		t.Parallel()
 		var i int16
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int16 value")
 		test.Ok(t, err)
@@ -80,6 +86,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int16 invalid", func(t *testing.T) {
+		t.Parallel()
 		var i int16
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int16 value")
 		test.Ok(t, err)
@@ -94,6 +101,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int32 valid", func(t *testing.T) {
+		t.Parallel()
 		var i int32
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int32 value")
 		test.Ok(t, err)
@@ -106,6 +114,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int32 invalid", func(t *testing.T) {
+		t.Parallel()
 		var i int32
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int32 value")
 		test.Ok(t, err)
@@ -120,6 +129,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int64 valid", func(t *testing.T) {
+		t.Parallel()
 		var i int64
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int64 value")
 		test.Ok(t, err)
@@ -132,6 +142,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int64 invalid", func(t *testing.T) {
+		t.Parallel()
 		var i int64
 		intFlag, err := flag.New(&i, "int", 'i', 0, "Set an int64 value")
 		test.Ok(t, err)
@@ -146,6 +157,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("count valid", func(t *testing.T) {
+		t.Parallel()
 		var c flag.Count
 		countFlag, err := flag.New(&c, "count", 'c', 0, "Count something")
 		test.Ok(t, err)
@@ -165,6 +177,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint valid", func(t *testing.T) {
+		t.Parallel()
 		var i uint
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint value")
 		test.Ok(t, err)
@@ -177,6 +190,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint invalid", func(t *testing.T) {
+		t.Parallel()
 		var i uint
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint value")
 		test.Ok(t, err)
@@ -191,6 +205,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint8 valid", func(t *testing.T) {
+		t.Parallel()
 		var i uint8
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint8 value")
 		test.Ok(t, err)
@@ -203,6 +218,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint8 invalid", func(t *testing.T) {
+		t.Parallel()
 		var i uint8
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint8 value")
 		test.Ok(t, err)
@@ -217,6 +233,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint16 valid", func(t *testing.T) {
+		t.Parallel()
 		var i uint16
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint16 value")
 		test.Ok(t, err)
@@ -229,6 +246,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint16 invalid", func(t *testing.T) {
+		t.Parallel()
 		var i uint16
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint16 value")
 		test.Ok(t, err)
@@ -243,6 +261,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint32 valid", func(t *testing.T) {
+		t.Parallel()
 		var i uint32
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint32 value")
 		test.Ok(t, err)
@@ -255,6 +274,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint32 invalid", func(t *testing.T) {
+		t.Parallel()
 		var i uint32
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint32 value")
 		test.Ok(t, err)
@@ -269,6 +289,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint64 valid", func(t *testing.T) {
+		t.Parallel()
 		var i uint64
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint64 value")
 		test.Ok(t, err)
@@ -281,6 +302,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint64 invalid", func(t *testing.T) {
+		t.Parallel()
 		var i uint64
 		intFlag, err := flag.New(&i, "uint", 'i', 0, "Set a uint64 value")
 		test.Ok(t, err)
@@ -295,6 +317,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uintptr valid", func(t *testing.T) {
+		t.Parallel()
 		var i uintptr
 		intFlag, err := flag.New(&i, "uintptr", 'i', 0, "Set a uintptr value")
 		test.Ok(t, err)
@@ -307,6 +330,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uintptr invalid", func(t *testing.T) {
+		t.Parallel()
 		var i uintptr
 		intFlag, err := flag.New(&i, "uintptr", 'i', 0, "Set a uintptr value")
 		test.Ok(t, err)
@@ -321,6 +345,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("float32 valid", func(t *testing.T) {
+		t.Parallel()
 		var f float32
 		floatFlag, err := flag.New(&f, "float", 'f', 0, "Set a float32 value")
 		test.Ok(t, err)
@@ -333,6 +358,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("float32 invalid", func(t *testing.T) {
+		t.Parallel()
 		var f float32
 		floatFlag, err := flag.New(&f, "float", 'f', 0, "Set a float32 value")
 		test.Ok(t, err)
@@ -347,6 +373,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("float64 valid", func(t *testing.T) {
+		t.Parallel()
 		var f float64
 		floatFlag, err := flag.New(&f, "float", 'f', 0, "Set a float64 value")
 		test.Ok(t, err)
@@ -359,6 +386,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("float64 invalid", func(t *testing.T) {
+		t.Parallel()
 		var f float64
 		floatFlag, err := flag.New(&f, "float", 'f', 0, "Set a float64 value")
 		test.Ok(t, err)
@@ -373,6 +401,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("bool valid", func(t *testing.T) {
+		t.Parallel()
 		var b bool
 		boolFlag, err := flag.New(&b, "bool", 'b', false, "Set a bool value")
 		test.Ok(t, err)
@@ -385,6 +414,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("bool invalid", func(t *testing.T) {
+		t.Parallel()
 		var b bool
 		boolFlag, err := flag.New(&b, "bool", 'b', false, "Set a bool value")
 		test.Ok(t, err)
@@ -401,6 +431,7 @@ func TestFlaggableTypes(t *testing.T) {
 	// No invalid case as all command line args are strings anyway so no real way of
 	// getting an error here
 	t.Run("string", func(t *testing.T) {
+		t.Parallel()
 		var str string
 		strFlag, err := flag.New(&str, "string", 's', "", "Set a string value")
 		test.Ok(t, err)
@@ -413,6 +444,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("byte slice valid", func(t *testing.T) {
+		t.Parallel()
 		var byt []byte
 		byteFlag, err := flag.New(&byt, "byte", 'b', []byte(""), "Set a byte slice value")
 		test.Ok(t, err)
@@ -425,6 +457,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("byte slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var byt []byte
 		byteFlag, err := flag.New(&byt, "byte", 'b', []byte(""), "Set a byte slice value")
 		test.Ok(t, err)
@@ -439,6 +472,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("time.Time valid", func(t *testing.T) {
+		t.Parallel()
 		var tyme time.Time
 		timeFlag, err := flag.New(&tyme, "time", 't', time.Now(), "Set a time value")
 		test.Ok(t, err)
@@ -454,6 +488,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("time.Time invalid", func(t *testing.T) {
+		t.Parallel()
 		var tyme time.Time
 		timeFlag, err := flag.New(&tyme, "time", 't', time.Now(), "Set a time value")
 		test.Ok(t, err)
@@ -468,6 +503,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("time.Duration valid", func(t *testing.T) {
+		t.Parallel()
 		var duration time.Duration
 		durationFlag, err := flag.New(
 			&duration,
@@ -489,6 +525,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("time.Duration invalid", func(t *testing.T) {
+		t.Parallel()
 		var duration time.Duration
 		durationFlag, err := flag.New(
 			&duration,
@@ -509,6 +546,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("ip valid", func(t *testing.T) {
+		t.Parallel()
 		var ip net.IP
 		ipFlag, err := flag.New(&ip, "ip", 'i', nil, "Set an IP address")
 		test.Ok(t, err)
@@ -521,6 +559,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("ip invalid", func(t *testing.T) {
+		t.Parallel()
 		var ip net.IP
 		ipFlag, err := flag.New(&ip, "ip", 'i', nil, "Set an IP address")
 		test.Ok(t, err)
@@ -535,6 +574,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of ints")
 		test.Ok(t, err)
@@ -555,6 +595,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of integers")
 		test.Ok(t, err)
@@ -569,6 +610,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int8 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int8
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of ints")
 		test.Ok(t, err)
@@ -589,6 +631,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int8 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int8
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of integers")
 		test.Ok(t, err)
@@ -603,6 +646,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int16 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int16
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of ints")
 		test.Ok(t, err)
@@ -623,6 +667,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int16 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int16
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of integers")
 		test.Ok(t, err)
@@ -637,6 +682,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int32 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int32
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of ints")
 		test.Ok(t, err)
@@ -657,6 +703,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int32 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int32
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of integers")
 		test.Ok(t, err)
@@ -671,6 +718,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int64 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int64
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of ints")
 		test.Ok(t, err)
@@ -691,6 +739,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("int64 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []int64
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of integers")
 		test.Ok(t, err)
@@ -705,6 +754,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []uint
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of uints")
 		test.Ok(t, err)
@@ -725,6 +775,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []uint
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of unsigned integers")
 		test.Ok(t, err)
@@ -739,6 +790,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint16 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []uint16
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of ints")
 		test.Ok(t, err)
@@ -759,6 +811,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint16 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []uint16
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of integers")
 		test.Ok(t, err)
@@ -773,6 +826,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint32 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []uint32
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of ints")
 		test.Ok(t, err)
@@ -793,6 +847,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint32 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []uint32
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of integers")
 		test.Ok(t, err)
@@ -807,6 +862,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint64 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []uint64
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of ints")
 		test.Ok(t, err)
@@ -827,6 +883,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("uint64 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []uint64
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of integers")
 		test.Ok(t, err)
@@ -841,6 +898,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("float32 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []float32
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of floats")
 		test.Ok(t, err)
@@ -861,6 +919,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("float32 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []float32
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of floats")
 		test.Ok(t, err)
@@ -875,6 +934,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("float64 slice valid", func(t *testing.T) {
+		t.Parallel()
 		var slice []float64
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Append to a slice of floats")
 		test.Ok(t, err)
@@ -895,6 +955,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("float64 slice invalid", func(t *testing.T) {
+		t.Parallel()
 		var slice []float64
 		sliceFlag, err := flag.New(&slice, "slice", 's', nil, "Slice of floats")
 		test.Ok(t, err)
@@ -909,6 +970,7 @@ func TestFlaggableTypes(t *testing.T) {
 	})
 
 	t.Run("string slice valid", func(t *testing.T) {
+		t.Parallel()
 		// Note: no invalid case for []string because *every* flag value is a string
 		// it's impossible to make a bad one
 		var slice []string
@@ -932,6 +994,7 @@ func TestFlaggableTypes(t *testing.T) {
 }
 
 func TestFlagValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string // Name of the test case
 		flagName string // Input flag name
@@ -1035,6 +1098,7 @@ func TestFlagValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := flag.New(new(string), tt.flagName, tt.short, "", "Test me")
 			test.WantErr(t, err, tt.wantErr)
 
@@ -1046,7 +1110,9 @@ func TestFlagValidation(t *testing.T) {
 }
 
 func TestFlagNilSafety(t *testing.T) {
+	t.Parallel()
 	t.Run("with new", func(t *testing.T) {
+		t.Parallel()
 		// Should be impossible to make a nil pointer dereference when using .New
 		var bang *bool
 
@@ -1058,6 +1124,7 @@ func TestFlagNilSafety(t *testing.T) {
 	})
 
 	t.Run("composite literal", func(t *testing.T) {
+		t.Parallel()
 		// Users doing naughty things, should still be nil safe
 		flag := flag.Flag[bool]{}
 		test.Equal(t, flag.String(), "<nil>")

--- a/internal/flag/set_test.go
+++ b/internal/flag/set_test.go
@@ -18,6 +18,7 @@ var (
 )
 
 func TestParse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string                            // The name of the test case
 		errMsg  string                            // If we did get an error, what should it say
@@ -965,6 +966,7 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			set := tt.newSet(t)
 			err := set.Parse(tt.args)
 			test.WantErr(t, err, tt.wantErr)
@@ -981,6 +983,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestFlagSet(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		newSet func(t *testing.T) *flag.Set      // Function to build the flag set under test
 		test   func(t *testing.T, set *flag.Set) // Function to test the set
@@ -1168,6 +1171,7 @@ func TestFlagSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			set := tt.newSet(t)
 			tt.test(t, set)
 		})
@@ -1175,6 +1179,7 @@ func TestFlagSet(t *testing.T) {
 }
 
 func TestHelpVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		newSet func(t *testing.T) *flag.Set      // Function to build the flag set under test
 		test   func(t *testing.T, set *flag.Set) // Function to test the set
@@ -1338,6 +1343,7 @@ func TestHelpVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			set := tt.newSet(t)
 			tt.test(t, set)
 		})
@@ -1345,6 +1351,7 @@ func TestHelpVersion(t *testing.T) {
 }
 
 func TestUsage(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		newSet func(t *testing.T) *flag.Set // Function to build the flag set under test
 		name   string                       // Name of the test case
@@ -1440,10 +1447,11 @@ func TestUsage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			snap := snapshot.New(t, snapshot.Update(*update))
 			set := tt.newSet(t)
 
-			colour.Disable = true // For testing
+			colour.Disable.Store(true) // For testing
 
 			got, err := set.Usage()
 			test.Ok(t, err)

--- a/internal/table/table_test.go
+++ b/internal/table/table_test.go
@@ -17,6 +17,7 @@ var (
 )
 
 func TestTable(t *testing.T) {
+	t.Parallel()
 	snap := snapshot.New(t, snapshot.Update(*update))
 	buf := &bytes.Buffer{}
 

--- a/option.go
+++ b/option.go
@@ -182,7 +182,7 @@ func Stderr(stderr io.Writer) Option {
 func NoColour(noColour bool) Option {
 	f := func(_ *config) error {
 		// Just disable the internal colour package entirely
-		colour.Disable = noColour
+		colour.Disable.Store(noColour)
 
 		return nil
 	}


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Hasn't made it any faster (not that it was slow). But it did expose a race condition with `colour.Disable`
