### PR TITLE
Optimise help and usage buffer size

### DIFF
--- a/command.go
+++ b/command.go
@@ -15,6 +15,9 @@ import (
 	"github.com/FollowTheProcess/cli/internal/table"
 )
 
+// helpBufferSize is sufficient to hold most command --help text.
+const helpBufferSize = 1024
+
 // Builder is a function that constructs and returns a [Command], it makes constructing
 // complex command trees easier as they can be passed directly to the [SubCommands] option.
 type Builder func() (*Command, error)
@@ -497,6 +500,7 @@ func defaultHelp(cmd *Command) error {
 	// significant increase in memory consumption and disk space.
 	// See https://github.com/spf13/cobra/issues/2015
 	s := &strings.Builder{}
+	s.Grow(helpBufferSize)
 
 	// If we have a short description, write that
 	if cmd.short != "" {

--- a/internal/flag/set.go
+++ b/internal/flag/set.go
@@ -11,6 +11,9 @@ import (
 	"github.com/FollowTheProcess/cli/internal/table"
 )
 
+// usageBufferSize is sufficient to hold most commands flag usage text.
+const usageBufferSize = 256
+
 // Set is a set of command line flags.
 type Set struct {
 	flags      map[string]Value // The actual stored flags, can lookup by name
@@ -186,6 +189,7 @@ func (s *Set) Parse(args []string) (err error) {
 // Usage returns a string containing the usage info of all flags in the set.
 func (s *Set) Usage() (string, error) {
 	buf := &bytes.Buffer{}
+	buf.Grow(usageBufferSize)
 
 	// Flags should be sorted alphabetically
 	names := make([]string, 0, len(s.flags))


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Grow the initial buffer for the help and usage text

```plaintext
goos: darwin
goarch: arm64
pkg: github.com/FollowTheProcess/cli
cpu: Apple M4 Pro
               │ before.txt  │             after.txt              │
               │   sec/op    │   sec/op     vs base               │
ExecuteHelp-14   2.251µ ± 0%   2.072µ ± 0%  -7.95% (p=0.000 n=30)

               │  before.txt  │              after.txt               │
               │     B/op     │     B/op      vs base                │
ExecuteHelp-14   5.246Ki ± 0%   4.214Ki ± 0%  -19.68% (p=0.000 n=30)

               │ before.txt │             after.txt             │
               │ allocs/op  │ allocs/op   vs base               │
ExecuteHelp-14   75.00 ± 0%   68.00 ± 0%  -9.33% (p=0.000 n=30)

```
